### PR TITLE
Fixed subgit pull issue

### DIFF
--- a/subgit/core.py
+++ b/subgit/core.py
@@ -453,7 +453,7 @@ class SubGit():
             g = Git(p)
 
             # Fetch all changes from upstream git repo
-            repo.remotes.origin.fetch()
+            repo.remotes.origin.pull()
 
             # How to handle the repo when a branch is specified
             if "branch" in revision:


### PR DESCRIPTION
So in the previous code, after the inital cloning of a repo, subgit would only fetch and create a local branch based on the `revision: branch:` in the `.subgit.yml` file. This creates a problem because while fetching from the remote, nothing is merged locally, which in turn created a bug if you had any un-pulled changes as shown in issue: #50 

The change made is only a change from `fetch()` to `pull()` which seems to do the trick while testing.

This is the relevant output i got when i tried to replicate the issue invoking `DEBUG=1`:

```
DEBUG - git.cmd:976 - Popen(['git', 'fetch', '-v', '--', 'origin'], cwd=/home/vberg/tmp/testing-sgit/randzone, universal_newlines=True, shell=None, istream=None)
DEBUG - subgit.core:460 - Handling branch pull case
DEBUG - git.cmd:976 - Popen(['git', 'cat-file', '--batch-check'], cwd=/home/vberg/tmp/testing-sgit/randzone, universal_newlines=False, shell=None, istream=<valid stream>)
Traceback (most recent call last):
  File "/home/vberg/code/dynamist/subgit/subgit/cli.py", line 309, in cli_entrypoint
    exit_code = run(cli_args, sub_args)
  File "/home/vberg/code/dynamist/subgit/subgit/cli.py", line 250, in run
    retcode = core.pull(repos)
  File "/home/vberg/code/dynamist/subgit/subgit/core.py", line 466, in pull
    repo.create_head(f"{branch_revision}", f"origin/{branch_revision}")
  File "/home/vberg/.virtualenvs/subgit/lib/python3.10/site-packages/git/repo/base.py", line 490, in create_head
    return Head.create(self, path, commit, logmsg, force)
  File "/home/vberg/.virtualenvs/subgit/lib/python3.10/site-packages/git/refs/symbolic.py", line 615, in create
    return cls._create(repo, path, cls._resolve_ref_on_create, reference, force, logmsg)
  File "/home/vberg/.virtualenvs/subgit/lib/python3.10/site-packages/git/refs/symbolic.py", line 567, in _create
    raise OSError(
OSError: Reference at 'refs/heads/master' does already exist, pointing to '7a11dca81c025aa270f7c3842312a985936db251', requested was '3cca3a41d1119ba9dc9f78260f73806be668d309'
Traceback (most recent call last):
  File "/home/vberg/.virtualenvs/subgit/bin/subgit", line 33, in <module>
    sys.exit(load_entry_point('subgit', 'console_scripts', 'subgit')())
  File "/home/vberg/code/dynamist/subgit/subgit/cli.py", line 309, in cli_entrypoint
    exit_code = run(cli_args, sub_args)
  File "/home/vberg/code/dynamist/subgit/subgit/cli.py", line 250, in run
    retcode = core.pull(repos)
  File "/home/vberg/code/dynamist/subgit/subgit/core.py", line 466, in pull
    repo.create_head(f"{branch_revision}", f"origin/{branch_revision}")
  File "/home/vberg/.virtualenvs/subgit/lib/python3.10/site-packages/git/repo/base.py", line 490, in create_head
    return Head.create(self, path, commit, logmsg, force)
  File "/home/vberg/.virtualenvs/subgit/lib/python3.10/site-packages/git/refs/symbolic.py", line 615, in create
    return cls._create(repo, path, cls._resolve_ref_on_create, reference, force, logmsg)
  File "/home/vberg/.virtualenvs/subgit/lib/python3.10/site-packages/git/refs/symbolic.py", line 567, in _create
    raise OSError(
OSError: Reference at 'refs/heads/master' does already exist, pointing to '7a11dca81c025aa270f7c3842312a985936db251', requested was '3cca3a41d1119ba9dc9f78260f73806be668d309'

```

git log output before change:

```
* 3cca3a4 - (66 seconds ago) Testing again - Viktor Berg (origin/master, origin/HEAD)   
* 7a11dca - (5 minutes ago) Using repo for testing - Viktor Berg (HEAD -> master)
* 257d853 - (19 hours ago) Change in README - Viktor Berg
...
```

Relevant subgit pull output after the change:

```
DEBUG - subgit.core:78 - /home/vberg/tmp/testing-sgit/.subgit.yml
DEBUG - subgit.core:336 - Repo pull - None
Are you sure you want to 'git pull' the following repos 'randzone'
INFO - subgit.core:244 - --yes flag set, automatically answer yes to question
DEBUG - git.cmd:976 - Popen(['git', 'diff', '--cached', '--abbrev=40', '--full-index', '--raw'], cwd=/home/vberg/tmp/testing-sgit/randzone, universal_newlines=False, shell=None, istream=None)
DEBUG - git.cmd:976 - Popen(['git', 'diff', '--abbrev=40', '--full-index', '--raw'], cwd=/home/vberg/tmp/testing-sgit/randzone, universal_newlines=False, shell=None, istream=None)
INFO - subgit.core:423 - 
DEBUG - subgit.core:448 - TODO: Parse for any changes...
DEBUG - git.cmd:976 - Popen(['git', 'pull', '-v', '--', 'origin'], cwd=/home/vberg/tmp/testing-sgit/randzone, universal_newlines=True, shell=None, istream=None)
DEBUG - subgit.core:460 - Handling branch pull case
DEBUG - git.cmd:976 - Popen(['git', 'cat-file', '--batch-check'], cwd=/home/vberg/tmp/testing-sgit/randzone, universal_newlines=False, shell=None, istream=<valid stream>)
DEBUG - git.cmd:976 - Popen(['git', 'checkout', 'master'], cwd=/home/vberg/tmp/testing-sgit/randzone, universal_newlines=False, shell=None, istream=None)
INFO - subgit.core:472 - Successfully pull repo "randzone" to latest commit on branch "master"
INFO - subgit.core:473 - Current git hash on HEAD: 3cca3a41d1119ba9dc9f78260f73806be668d309
```

git log after change:

```
* 3cca3a4 - (3 minutes ago) Testing again - Viktor Berg (HEAD -> master, origin/master, origin/HEAD)
* 7a11dca - (6 minutes ago) Using repo for testing - Viktor Berg
* 257d853 - (19 hours ago) Change in README - Viktor Berg
* 19bf4d3 - (20 hours ago) Small change in README - Viktor Berg
...
```

Refers to issue #50 