### PR TITLE
F/change import command

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     maintainer="Johan Andersson",
     maintainer_email="johan@dynamist.se",
     license="Apache License 2.0",
-    packages=["subgit", "subgit.importer"],
+    packages=["subgit", "subgit.inspect"],
     url="http://github.com/dynamist/sgit",
     entry_points={
         "console_scripts": [

--- a/subgit/cli.py
+++ b/subgit/cli.py
@@ -20,7 +20,7 @@ Commands:
     pull     Update one or all Git repos
     status   Show status of each configured repo
     delete   Delete one or more local Git repos
-    import   import repos from github or gitlab and creates a config file
+    inspect  Listing repos from github or gitlab
     reset    Reset repo(s) previous tracked state
     clean    Clean repo(s) from untracked files
 
@@ -107,13 +107,13 @@ Options:
 """
 
 
-sub_import_args = """
+sub_inspect_args = """
 Usage:
-    subgit import (github | gitlab) <owner> [options]
+    subgit inspect (github | gitlab) <owner> [options]
 
 Options:
     -y, --yes                                Answers yes to all questions (use with caution)
-    -o <filename>, --output-file <filename>  Used to specify output filename
+    -o <filename>, --output-file <filename>  Used if inspect output should be directed to a .subgit.yml file
     -a, --archived                           Writes only archived repos to output file
     -h, --help                               Show this help message and exit
 
@@ -185,8 +185,8 @@ def parse_cli():
         sub_args = docopt(sub_status_args, argv=argv)
     elif cli_args["<command>"] == "delete":
         sub_args = docopt(sub_delete_args, argv=argv)
-    elif cli_args["<command>"] == "import":
-        sub_args = docopt(sub_import_args, argv=argv)
+    elif cli_args["<command>"] == "inspect":
+        sub_args = docopt(sub_inspect_args, argv=argv)
     elif cli_args["<command>"] == "reset":
         sub_args = docopt(sub_reset_args, argv=argv)
     elif cli_args["<command>"] == "clean":
@@ -219,7 +219,7 @@ def run(cli_args, sub_args):
     log.debug(sub_args)
 
     from subgit.core import SubGit
-    from subgit.importer.git_importer import GitImport
+    from subgit.inspect.git_inspect import GitInspect
 
     core = SubGit(
         config_file_path=sub_args.get("--conf"),
@@ -270,8 +270,8 @@ def run(cli_args, sub_args):
             hard_flag=hard_flag,
         )
 
-    if cli_args["<command>"] == "import":
-        git_importer = GitImport(
+    if cli_args["<command>"] == "inspect":
+        git_inspect = GitInspect(
             config_file_name=sub_args.get("--output-file"), 
             answer_yes=sub_args["--yes"],
             is_archived=sub_args.get("--archived"),
@@ -281,10 +281,10 @@ def run(cli_args, sub_args):
         owner = sub_args["<owner>"]
         
         if github:
-            retcode = git_importer.import_github(owner)
+            retcode = git_inspect.inspect_github(owner)
         
         if gitlab:
-            retcode = git_importer.import_gitlab(owner)
+            retcode = git_inspect.inspect_gitlab(owner)
 
     if cli_args["<command>"] == "clean":
         repos = sub_args["<repo>"]

--- a/subgit/inspect/git_inspect.py
+++ b/subgit/inspect/git_inspect.py
@@ -12,11 +12,13 @@ from subgit.core import SubGit
 # 3rd party imports
 from ruamel import yaml
 
+import pysnooper
+
 
 log = logging.getLogger(__name__)
 
 
-class GitImport(SubGit):
+class GitInspect(SubGit):
     def __init__(self, config_file_name=None, answer_yes=None, is_archived=False):
         self.answer_yes = answer_yes
         self.is_archived = is_archived
@@ -56,7 +58,8 @@ class GitImport(SubGit):
 
         return True
 
-    def import_github(self, owner):
+    @pysnooper.snoop()
+    def inspect_github(self, owner):
         """
         Given a username or organisation name, this method lists all repos connected to it
         on github and writes a subgit config file.
@@ -97,7 +100,7 @@ class GitImport(SubGit):
             answer = self.yes_no(f"File: {self.subgit_config_file_path} already exists on disk, do you want to overwrite the file?")
 
             if not answer:
-                log.error("Aborting import")
+                log.error("Aborting inspection")
                 return 1
 
         for repo_name in sorted_names:
@@ -124,7 +127,7 @@ class GitImport(SubGit):
         log.info(f"Successfully wrote to file: {self.subgit_config_file_name}")
         return 0
 
-    def import_gitlab(self, owner):
+    def inspect_gitlab(self, owner):
         """
         Given a username or organisation name, this method lists all repos connected to it
         on gitlab and writes a subgit config file.
@@ -167,7 +170,7 @@ class GitImport(SubGit):
             answer = self.yes_no(f"File: {self.subgit_config_file_path} already exists on disk, do you want to overwrite the file?")
 
             if not answer:
-                log.error("Aborting import")
+                log.error("Aborting inspection")
                 return 1
 
         for repo_name in sorted_names:


### PR DESCRIPTION
Changed name of 'subgit import' to 'subgit inspect', as well as changed the main function so that it gives an example output as default and if the user where to specify an output file name, the output could be written to that file.

Output from 'subgit inspect github naestia' which doesn't specify a file name:

```
➜  testing-sgit  subgit inspect github naestia
Your '.subgit.yml' file would look like this:
repos:
  advent:
    revision:
      branch: master
    url: git@github.com:naestia/advent.git
  making-api:
    revision:
      branch: main
    url: git@github.com:naestia/making-api.git
  naestia:
    revision:
      branch: master
    url: git@github.com:naestia/naestia.git
  pajgejms:
    revision:
      branch: main
    url: git@github.com:naestia/pajgejms.git
  pymono:
    revision:
      branch: master
    url: git@github.com:naestia/pymono.git
  randzone:
    revision:
      branch: master
    url: git@github.com:naestia/randzone.git
  socket_learning:
    revision:
      branch: main
    url: git@github.com:naestia/socket_learning.git
  subgit-test-repo:
    revision:
      branch: master
    url: git@github.com:naestia/subgit-test-repo.git
```

Output when i add output file:

```
➜  testing-sgit  subgit inspect github naestia -o .subgit.yml
File: /home/vberg/tmp/testing-sgit/.subgit.yml already exists on disk, do you want to overwrite the file?
(y/n) << y
Successfully wrote to file: .subgit.yml
```

If the name provided already exists, subgit will ask if user wants to overwrite, otherwise it will just write a new file.

Fixes #47 as well as #48 